### PR TITLE
fix: guard document.lineAt() against out-of-range line numbers in outline provider

### DIFF
--- a/src/extension/outline.ts
+++ b/src/extension/outline.ts
@@ -20,17 +20,22 @@ class OfmDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
     // next heading of equal-or-higher level (or end of document).
     const stack: { level: number; sym: vscode.DocumentSymbol }[] = [];
 
+    const lineCount = document.lineCount;
+
     for (let k = 0; k < heads.length; k++) {
       const h = heads[k];
+      if (h.line < 0 || h.line >= lineCount) continue;
       const startLine = document.lineAt(h.line);
       // End line: line before the next heading of level <= this one.
-      let endLineNo = document.lineCount - 1;
+      let endLineNo = lineCount - 1;
       for (let n = k + 1; n < heads.length; n++) {
         if (heads[n].level <= h.level) {
           endLineNo = Math.max(h.line, heads[n].line - 1);
           break;
         }
       }
+      endLineNo = Math.min(endLineNo, lineCount - 1);
+      if (endLineNo < 0) continue;
       const range = new vscode.Range(
         startLine.range.start,
         document.lineAt(endLineNo).range.end


### PR DESCRIPTION
## Summary

- Add bounds checks before every `document.lineAt()` call in `provideDocumentSymbols` (`src/extension/outline.ts`)
- Prevents "Assertion Failed: Argument is `undefined` or `null`" when VS Code calls the symbol provider while the document is still loading

Fixes #3

## Root cause

When a `.md` file is opened directly with Flintmark as the default editor, VS Code calls `provideDocumentSymbols` eagerly (for breadcrumbs/outline). The heading line numbers parsed by `getSnapshot()` can be out of range if the `TextDocument` is still in a transitional state, causing `document.lineAt()` to throw.

## Changes

- Cache `lineCount` once at the top of the loop
- Skip headings with `h.line < 0 || h.line >= lineCount`
- Clamp `endLineNo` to `lineCount - 1`

## Test plan

- [x] Open `.md` files directly with Flintmark as default editor — no assertion errors
- [ ] Verify breadcrumbs and Outline view still work correctly
- [ ] Rapid file switching doesn't cause crashes

Made with [Cursor](https://cursor.com)